### PR TITLE
Ensure all files are removed on clobber

### DIFF
--- a/lib/tasks/clobber.rake
+++ b/lib/tasks/clobber.rake
@@ -1,8 +1,8 @@
 namespace :dartsass do
   desc "Remove CSS builds"
   task :clobber do
-    rm_rf Dir["app/assets/builds/[^.]*.css"], verbose: false
-    rm_rf Dir["app/assets/builds/[^.]*.css\.map"], verbose: false
+    rm_rf Dir["app/assets/builds/**/[^.]*.css"], verbose: false
+    rm_rf Dir["app/assets/builds/**/[^.]*.css\.map"], verbose: false
   end
 end
 


### PR DESCRIPTION
Currently, `dartsass:clobber` only looks for css and related maps files at the root of `app/assets/builds`.  Change to find files recursively within builds.